### PR TITLE
Feat/all exposures

### DIFF
--- a/products/dated-irs/src/libraries/ExposureHelpers.sol
+++ b/products/dated-irs/src/libraries/ExposureHelpers.sol
@@ -7,15 +7,15 @@ https://github.com/Voltz-Protocol/v2-core/blob/main/products/dated-irs/LICENSE
 */
 pragma solidity >=0.8.19;
 
-import "./Portfolio.sol";
+import "../storage/Portfolio.sol";
 import "@voltz-protocol/core/src/storage/Account.sol";
 import { UD60x18, UNIT } from "@prb/math/UD60x18.sol";
 import { mulUDxInt } from "@voltz-protocol/util-contracts/src/helpers/PrbMathHelper.sol";
 import "@voltz-protocol/util-contracts/src/helpers/Time.sol";
-import "./RateOracleReader.sol";
+import "../storage/RateOracleReader.sol";
 import "../interfaces/IPool.sol";
 import "@voltz-protocol/core/src/interfaces/IRiskConfigurationModule.sol";
-import "./ProductConfiguration.sol";
+import "../storage/ProductConfiguration.sol";
 
 /**
  * @title Object for tracking a portfolio of dated interest rate swap positions
@@ -105,7 +105,7 @@ library ExposureHelpers {
         }
     }
 
-    function getTraderExposureInPool(
+    function getOnlyFilledExposureInPool(
         Portfolio.PoolExposureState memory poolState,
         address poolAddress,
         address collateralType,
@@ -127,7 +127,7 @@ library ExposureHelpers {
         });
     }
 
-    function getMakerShortExposureInPool(
+    function getUnfilledExposureLowerInPool(
         Portfolio.PoolExposureState memory poolState,
         address poolAddress,
         address collateralType,
@@ -152,7 +152,7 @@ library ExposureHelpers {
         });
     }
 
-    function getMakerLongExposureInPool(
+    function getUnfilledExposureUpperInPool(
         Portfolio.PoolExposureState memory poolState,
         address poolAddress,
         address collateralType,

--- a/products/dated-irs/src/modules/ProductIRSModule.sol
+++ b/products/dated-irs/src/modules/ProductIRSModule.sol
@@ -142,7 +142,7 @@ contract ProductIRSModule is IProductIRSModule {
         returns (int256[] memory exposures)
     {
         exposures = new int256[](baseAmounts.length);
-        exposures = Portfolio.baseToAnnualizedExposure(baseAmounts, marketId, maturityTimestamp);
+        exposures = ExposureHelpers.baseToAnnualizedExposure(baseAmounts, marketId, maturityTimestamp);
     }
 
     /**
@@ -181,7 +181,9 @@ contract ProductIRSModule is IProductIRSModule {
         Account.Exposure[] memory makerExposuresUpper
     )
     {
-        // todo: needs implementation (IR)
+        Portfolio.Data storage portfolio = Portfolio.exists(accountId);
+        address poolAddress = ProductConfiguration.getPoolAddress();
+        return portfolio.getAccountTakerAndMakerExposuresAllCollaterals(poolAddress);
     }
 
     /**

--- a/products/dated-irs/src/storage/ExposureHelpers.sol
+++ b/products/dated-irs/src/storage/ExposureHelpers.sol
@@ -98,7 +98,7 @@ library ExposureHelpers {
         uint256 length
     ) internal pure returns (Account.Exposure[] memory exposuresWithoutEmptySlots) {
         // todo: consider into a utility library (CR)
-        require(exposures.length >= length);
+        require(exposures.length >= length, "Exp len");
         exposuresWithoutEmptySlots = new Account.Exposure[](length);
         for (uint256 i = 0; i < length; i++) {
             exposuresWithoutEmptySlots[i] = exposures[i];

--- a/products/dated-irs/src/storage/ExposureHelpers.sol
+++ b/products/dated-irs/src/storage/ExposureHelpers.sol
@@ -1,0 +1,179 @@
+/*
+Licensed under the Voltz v2 License (the "License"); you 
+may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://github.com/Voltz-Protocol/v2-core/blob/main/products/dated-irs/LICENSE
+*/
+pragma solidity >=0.8.19;
+
+import "./Portfolio.sol";
+import "@voltz-protocol/core/src/storage/Account.sol";
+import { UD60x18, UNIT } from "@prb/math/UD60x18.sol";
+import { mulUDxInt } from "@voltz-protocol/util-contracts/src/helpers/PrbMathHelper.sol";
+import "@voltz-protocol/util-contracts/src/helpers/Time.sol";
+import "./RateOracleReader.sol";
+import "../interfaces/IPool.sol";
+import "@voltz-protocol/core/src/interfaces/IRiskConfigurationModule.sol";
+import "./ProductConfiguration.sol";
+
+/**
+ * @title Object for tracking a portfolio of dated interest rate swap positions
+ */
+library ExposureHelpers {
+    using SafeCastU256 for uint256;
+    using RateOracleReader for RateOracleReader.Data;
+
+    function computeUnrealizedLoss(
+        uint128 marketId,
+        uint32 maturityTimestamp,
+        address poolAddress,
+        int256 baseBalance,
+        int256 quoteBalance
+    ) internal view returns (uint256 unrealizedLoss) {
+        int256 unwindQuote = computeUnwindQuote(marketId, maturityTimestamp, poolAddress, baseBalance);
+        int256 unrealizedPnL = quoteBalance + unwindQuote;
+
+        if (unrealizedPnL < 0) {
+            // todo: check if safecasting with .Uint() is necessary (CR)
+            unrealizedLoss = uint256(-unrealizedPnL);
+        }
+    }
+
+    function computeUnwindQuote(
+        uint128 marketId,
+        uint32 maturityTimestamp,
+        address poolAddress,
+        int256 baseAmount
+    )
+        internal
+        view
+        returns (int256 unwindQuote)
+    {
+        UD60x18 timeDeltaAnnualized = Time.timeDeltaAnnualized(maturityTimestamp);
+
+        UD60x18 currentLiquidityIndex = RateOracleReader.load(marketId).getRateIndexCurrent();
+
+        address coreProxy = ProductConfiguration.getCoreProxyAddress();
+        uint128 productId = ProductConfiguration.getProductId();
+        uint32 lookbackWindow =
+            IRiskConfigurationModule(coreProxy).getMarketRiskConfiguration(productId, marketId).twapLookbackWindow;
+
+        UD60x18 twap = IPool(poolAddress).getAdjustedDatedIRSTwap(marketId, maturityTimestamp, -baseAmount, lookbackWindow);
+
+        unwindQuote = mulUDxInt(twap.mul(timeDeltaAnnualized).add(UNIT), mulUDxInt(currentLiquidityIndex, baseAmount));
+    }
+
+    /**
+     * @dev in context of interest rate swaps, base refers to scaled variable tokens (e.g. scaled virtual aUSDC)
+     * @dev in order to derive the annualized exposure of base tokens in quote terms (i.e. USDC), we need to
+     * first calculate the (non-annualized) exposure by multiplying the baseAmount by the current liquidity index of the
+     * underlying rate oracle (e.g. aUSDC lend rate oracle)
+     */
+    function annualizedExposureFactor(uint128 marketId, uint32 maturityTimestamp) internal view returns (UD60x18 factor) {
+        UD60x18 currentLiquidityIndex = RateOracleReader.load(marketId).getRateIndexCurrent();
+        UD60x18 timeDeltaAnnualized = Time.timeDeltaAnnualized(maturityTimestamp);
+        factor = currentLiquidityIndex.mul(timeDeltaAnnualized);
+    }
+
+    function baseToAnnualizedExposure(
+        int256[] memory baseAmounts,
+        uint128 marketId,
+        uint32 maturityTimestamp
+    )
+        internal
+        view
+        returns (int256[] memory exposures)
+    {
+        exposures = new int256[](baseAmounts.length);
+        UD60x18 factor = annualizedExposureFactor(marketId, maturityTimestamp);
+
+        for (uint256 i = 0; i < baseAmounts.length; i++) {
+            exposures[i] = mulUDxInt(factor, baseAmounts[i]);
+        }
+    }
+
+    function removeEmptySlotsFromExposuresArray(
+        Account.Exposure[] memory exposures,
+        uint256 length
+    ) internal pure returns (Account.Exposure[] memory exposuresWithoutEmptySlots) {
+        // todo: consider into a utility library (CR)
+        require(exposures.length >= length);
+        exposuresWithoutEmptySlots = new Account.Exposure[](length);
+        for (uint256 i = 0; i < length; i++) {
+            exposuresWithoutEmptySlots[i] = exposures[i];
+        }
+    }
+
+    function getTraderExposureInPool(
+        Portfolio.PoolExposureState memory poolState,
+        address poolAddress,
+        address collateralType,
+        uint128 productId
+    ) internal view returns (Account.Exposure memory) {
+        uint256 unrealizedLoss = computeUnrealizedLoss(
+            poolState.marketId,
+            poolState.maturityTimestamp,
+            poolAddress,
+            poolState.baseBalance + poolState.baseBalancePool,
+            poolState.quoteBalance + poolState.quoteBalancePool
+        );
+        return Account.Exposure({
+            productId: productId,
+            marketId: poolState.marketId,
+            annualizedNotional: mulUDxInt(poolState._annualizedExposureFactor, poolState.baseBalance + poolState.baseBalancePool),
+            unrealizedLoss: unrealizedLoss,
+            collateralType: collateralType
+        });
+    }
+
+    function getMakerShortExposureInPool(
+        Portfolio.PoolExposureState memory poolState,
+        address poolAddress,
+        address collateralType,
+        uint128 productId
+    ) internal view returns (Account.Exposure memory) {
+        uint256 unrealizedLossLower = computeUnrealizedLoss(
+            poolState.marketId,
+            poolState.maturityTimestamp,
+            poolAddress,
+            poolState.baseBalance + poolState.baseBalancePool - poolState.unfilledBaseShort.toInt(),
+            poolState.quoteBalance + poolState.quoteBalancePool + poolState.unfilledQuoteShort.toInt()
+        );
+        return Account.Exposure({
+            productId: productId,
+            marketId: poolState.marketId,
+            annualizedNotional: mulUDxInt(
+                poolState._annualizedExposureFactor, 
+                poolState.baseBalance + poolState.baseBalancePool - poolState.unfilledBaseShort.toInt()
+            ),
+            unrealizedLoss: unrealizedLossLower,
+            collateralType: collateralType
+        });
+    }
+
+    function getMakerLongExposureInPool(
+        Portfolio.PoolExposureState memory poolState,
+        address poolAddress,
+        address collateralType,
+        uint128 productId
+    ) internal view returns (Account.Exposure memory) {
+        uint256 unrealizedLossUpper = computeUnrealizedLoss(
+            poolState.marketId,
+            poolState.maturityTimestamp,
+            poolAddress,
+            poolState.baseBalance + poolState.baseBalancePool + poolState.unfilledBaseLong.toInt(),
+            poolState.quoteBalance + poolState.quoteBalancePool - poolState.unfilledQuoteLong.toInt()
+        );
+        return Account.Exposure({
+            productId: productId,
+            marketId: poolState.marketId,
+            annualizedNotional: mulUDxInt(
+                poolState._annualizedExposureFactor,
+                poolState.baseBalance + poolState.baseBalancePool + poolState.unfilledBaseLong.toInt()
+            ),
+            unrealizedLoss: unrealizedLossUpper,
+            collateralType: collateralType
+        });
+    }
+}

--- a/products/dated-irs/src/storage/Portfolio.sol
+++ b/products/dated-irs/src/storage/Portfolio.sol
@@ -286,14 +286,12 @@ library Portfolio {
         for (uint256 i = 0; i < self.activeCollateralTypes.length(); i++) {
             address collateralType = self.activeCollateralTypes.valueAt(i+1);
 
-            uint256 _takerExposuresLength;
-            uint256 _makerExposuresLowerAndUpperLength;
             (
                 takerExposuresPadded,
                 makerExposuresLowerPadded,
                 makerExposuresUpperPadded,
-                _takerExposuresLength,
-                _makerExposuresLowerAndUpperLength
+                takerExposuresLength,
+                makerExposuresLowerAndUpperLength
             ) = getAccountTakerAndMakerExposuresWithEmptySlots(
                 self,
                 poolAddress,
@@ -306,8 +304,6 @@ library Portfolio {
                     makerIndex: makerExposuresLowerAndUpperLength
                 })
             );
-            takerExposuresLength += _takerExposuresLength;
-            makerExposuresLowerAndUpperLength += _makerExposuresLowerAndUpperLength;
         }
 
         takerExposures = ExposureHelpers.removeEmptySlotsFromExposuresArray(takerExposuresPadded, takerExposuresLength);

--- a/products/dated-irs/src/storage/Portfolio.sol
+++ b/products/dated-irs/src/storage/Portfolio.sol
@@ -17,7 +17,7 @@ import "./RateOracleReader.sol";
 import "./MarketConfiguration.sol";
 import "./ProductConfiguration.sol";
 import "../interfaces/IPool.sol";
-import "./ExposureHelpers.sol";
+import "../libraries/ExposureHelpers.sol";
 import "@voltz-protocol/core/src/storage/Account.sol";
 import "@voltz-protocol/core/src/interfaces/IRiskConfigurationModule.sol";
 import { UD60x18, UNIT, unwrap } from "@prb/math/UD60x18.sol";
@@ -178,14 +178,14 @@ library Portfolio {
             if (poolState.unfilledBaseLong == 0 && poolState.unfilledBaseShort == 0) {
                 // no unfilled exposures => only consider taker exposures
                 initExposures.taker[collateralState.takerExposuresLength] = 
-                    ExposureHelpers.getTraderExposureInPool(poolState, poolAddress, collateralType, collateralState.productId);
+                    ExposureHelpers.getOnlyFilledExposureInPool(poolState, poolAddress, collateralType, collateralState.productId);
                 collateralState.takerExposuresLength = collateralState.takerExposuresLength + 1;
             } else {
                 // unfilled exposures => consider maker lower
                 initExposures.makerLower[collateralState.makerExposuresLowerAndUpperLength] = 
-                    ExposureHelpers.getMakerShortExposureInPool(poolState, poolAddress, collateralType, collateralState.productId);
+                    ExposureHelpers.getUnfilledExposureLowerInPool(poolState, poolAddress, collateralType, collateralState.productId);
                 initExposures.makerUpper[collateralState.makerExposuresLowerAndUpperLength] = 
-                    ExposureHelpers.getMakerLongExposureInPool(poolState, poolAddress, collateralType, collateralState.productId);
+                    ExposureHelpers.getUnfilledExposureUpperInPool(poolState, poolAddress, collateralType, collateralState.productId);
 
                 collateralState.makerExposuresLowerAndUpperLength = collateralState.makerExposuresLowerAndUpperLength + 1;
             }

--- a/products/dated-irs/src/storage/Portfolio.sol
+++ b/products/dated-irs/src/storage/Portfolio.sol
@@ -214,7 +214,10 @@ library Portfolio {
             poolState.marketId, poolState.maturityTimestamp, self.accountId);
         (poolState.unfilledBaseLong, poolState.unfilledBaseShort, poolState.unfilledQuoteLong, poolState.unfilledQuoteShort) =
             IPool(poolAddress).getAccountUnfilledBaseAndQuote(poolState.marketId, poolState.maturityTimestamp, self.accountId);
-        poolState._annualizedExposureFactor = ExposureHelpers.annualizedExposureFactor(poolState.marketId, poolState.maturityTimestamp);
+        poolState._annualizedExposureFactor = ExposureHelpers.annualizedExposureFactor(
+            poolState.marketId,
+            poolState.maturityTimestamp
+        );
     }
 
     function getAccountTakerAndMakerExposures(
@@ -252,9 +255,18 @@ library Portfolio {
             })
         );
 
-        takerExposures = ExposureHelpers.removeEmptySlotsFromExposuresArray(takerExposuresPadded, takerExposuresLength);
-        makerExposuresLower = ExposureHelpers.removeEmptySlotsFromExposuresArray(makerExposuresLowerPadded, makerExposuresLowerAndUpperLength);
-        makerExposuresUpper = ExposureHelpers.removeEmptySlotsFromExposuresArray(makerExposuresUpperPadded, makerExposuresLowerAndUpperLength);
+        takerExposures = ExposureHelpers.removeEmptySlotsFromExposuresArray(
+            takerExposuresPadded,
+            takerExposuresLength
+        );
+        makerExposuresLower = ExposureHelpers.removeEmptySlotsFromExposuresArray(
+            makerExposuresLowerPadded,
+            makerExposuresLowerAndUpperLength
+        );
+        makerExposuresUpper = ExposureHelpers.removeEmptySlotsFromExposuresArray(
+            makerExposuresUpperPadded,
+            makerExposuresLowerAndUpperLength
+        );
 
         return (takerExposures, makerExposuresLower, makerExposuresUpper);
     }
@@ -306,9 +318,18 @@ library Portfolio {
             );
         }
 
-        takerExposures = ExposureHelpers.removeEmptySlotsFromExposuresArray(takerExposuresPadded, takerExposuresLength);
-        makerExposuresLower = ExposureHelpers.removeEmptySlotsFromExposuresArray(makerExposuresLowerPadded, makerExposuresLowerAndUpperLength);
-        makerExposuresUpper = ExposureHelpers.removeEmptySlotsFromExposuresArray(makerExposuresUpperPadded, makerExposuresLowerAndUpperLength);
+        takerExposures = ExposureHelpers.removeEmptySlotsFromExposuresArray(
+            takerExposuresPadded,
+            takerExposuresLength
+        );
+        makerExposuresLower = ExposureHelpers.removeEmptySlotsFromExposuresArray(
+            makerExposuresLowerPadded,
+            makerExposuresLowerAndUpperLength
+        );
+        makerExposuresUpper = ExposureHelpers.removeEmptySlotsFromExposuresArray(
+            makerExposuresUpperPadded,
+            makerExposuresLowerAndUpperLength
+        );
 
         return (takerExposures, makerExposuresLower, makerExposuresUpper);
     }

--- a/products/dated-irs/test/modules/ProductIRSModule.t.sol
+++ b/products/dated-irs/test/modules/ProductIRSModule.t.sol
@@ -741,7 +741,9 @@ contract ProductIRSModuleTest is Test {
         );
         vm.mockCall(
             address(2),
-            abi.encodeWithSelector(IPool.getAccountUnfilledBaseAndQuote.selector, MOCK_MARKET_ID2, maturityTimestamp, MOCK_ACCOUNT_ID),
+            abi.encodeWithSelector(
+                IPool.getAccountUnfilledBaseAndQuote.selector, MOCK_MARKET_ID2, maturityTimestamp, MOCK_ACCOUNT_ID
+            ),
             abi.encode(10, 10, 11, 11)
         );
         vm.mockCall(

--- a/products/dated-irs/test/modules/ProductIRSModule.t.sol
+++ b/products/dated-irs/test/modules/ProductIRSModule.t.sol
@@ -680,7 +680,7 @@ contract ProductIRSModuleTest is Test {
             Account.Exposure[] memory makerExposuresUpper
         ) = productIrs.getAccountTakerAndMakerExposures(MOCK_ACCOUNT_ID, MOCK_QUOTE_TOKEN);
 
-        // todo: layer in asserts
+        // todo: layer in asserts (AB)
 //        assertEq(exposures.length, 1);
 //        assertEq(exposures[0].marketId, MOCK_MARKET_ID);
 //        assertEq(exposures[0].filled, 20);

--- a/products/dated-irs/test/storage/Portfolio.t.sol
+++ b/products/dated-irs/test/storage/Portfolio.t.sol
@@ -72,7 +72,7 @@ contract ExposePortfolio {
 
 
     function annualizedExposureFactor(uint128 marketId, uint32 maturityTimestamp) external returns (UD60x18) {
-        return Portfolio.annualizedExposureFactor(marketId, maturityTimestamp);
+        return ExposureHelpers.annualizedExposureFactor(marketId, maturityTimestamp);
     }
 
     function baseToAnnualizedExposure(
@@ -83,7 +83,7 @@ contract ExposePortfolio {
         external
         returns (int256[] memory)
     {
-        return Portfolio.baseToAnnualizedExposure(baseAmounts, marketId, maturityTimestamp);
+        return ExposureHelpers.baseToAnnualizedExposure(baseAmounts, marketId, maturityTimestamp);
     }
 
     function activateMarketMaturity(uint128 id, uint128 marketId, uint32 maturityTimestamp) external {
@@ -138,7 +138,7 @@ contract ExposePortfolio {
         view
         returns (int256 unwindQuote)
     {
-        unwindQuote = Portfolio.computeUnwindQuote(marketId, maturityTimestamp, poolAddress, baseAmount);
+        unwindQuote = ExposureHelpers.computeUnwindQuote(marketId, maturityTimestamp, poolAddress, baseAmount);
     }
 
     function updateRateIndexAtMaturityCache(uint128 id, uint32 maturityTimestamp) external {
@@ -160,7 +160,7 @@ contract ExposePortfolio {
         int256 baseBalance,
         int256 quoteBalance
     ) external view returns (uint256 unrealizedLoss) {
-        unrealizedLoss = Portfolio.computeUnrealizedLoss(
+        unrealizedLoss = ExposureHelpers.computeUnrealizedLoss(
             marketId,
             maturityTimestamp,
             poolAddress,
@@ -173,15 +173,7 @@ contract ExposePortfolio {
         Account.Exposure[] memory exposures,
         uint256 length
     ) external pure returns (Account.Exposure[] memory exposuresWithoutEmptySlots) {
-        exposuresWithoutEmptySlots = Portfolio.removeEmptySlotsFromExposuresArray(exposures, length);
-    }
-
-    function getAccountTakerAndMakerExposuresWithEmptySlots(
-        uint128 id,
-        address poolAddress,
-        address collateralType
-    ) external view returns (Account.Exposure[] memory, Account.Exposure[] memory, Account.Exposure[] memory, uint256, uint256)  {
-        return Portfolio.load(id).getAccountTakerAndMakerExposuresWithEmptySlots(poolAddress, collateralType);
+        exposuresWithoutEmptySlots = ExposureHelpers.removeEmptySlotsFromExposuresArray(exposures, length);
     }
 
     // EXTRA GETTERS


### PR DESCRIPTION
Changes
- refactored get exposure logic in Portfolio to accommodate for multiple collateral types
- store active collateral types in the portfolio (it doesn't seem necessary to deactivate them, the logic will be too complex for the small gas savings in the future)
- exposes a function that returns an array of trader/makerShort/makerLong exposures for all collateral types ever activated by the account