### PR TITLE
feat: collateral pool pausability

### DIFF
--- a/core/src/modules/CollateralModule.sol
+++ b/core/src/modules/CollateralModule.sol
@@ -21,6 +21,7 @@ contract CollateralModule is ICollateralModule {
     using ERC20Helper for address;
     using CollateralConfiguration for CollateralConfiguration.Data;
     using Account for Account.Data;
+    using CollateralPool for CollateralPool.Data;
     using SafeCastI256 for int256;
     using SafeCastU256 for uint256;
 
@@ -37,6 +38,8 @@ contract CollateralModule is ICollateralModule {
 
         // grab the account and check its existance
         Account.Data storage account = Account.exists(accountId);
+
+        account.ensureEnabledCollateralPool();
 
         address depositFrom = msg.sender;
         address self = address(this);
@@ -70,6 +73,8 @@ contract CollateralModule is ICollateralModule {
         FeatureFlag.ensureAccessToFeature(_GLOBAL_FEATURE_FLAG);
         Account.Data storage account =
             Account.loadAccountAndValidatePermission(accountId, Account.ADMIN_PERMISSION, msg.sender);
+
+        account.ensureEnabledCollateralPool();
 
         account.decreaseCollateralBalance(collateralType, tokenAmount);
 

--- a/core/src/modules/LiquidationModule.sol
+++ b/core/src/modules/LiquidationModule.sol
@@ -31,6 +31,7 @@ import {mulUDxUint} from "@voltz-protocol/util-contracts/src/helpers/PrbMathHelp
 contract LiquidationModule is ILiquidationModule {
     using CollateralConfiguration for CollateralConfiguration.Data;
     using Account for Account.Data;
+    using CollateralPool for CollateralPool.Data;
     using SafeCastU256 for uint256;
     using SafeCastI256 for int256;
 
@@ -72,6 +73,8 @@ contract LiquidationModule is ILiquidationModule {
     {
         FeatureFlag.ensureAccessToFeature(_GLOBAL_FEATURE_FLAG);
         Account.Data storage account = Account.exists(liquidatedAccountId);
+
+        account.ensureEnabledCollateralPool();
 
         if (account.accountMode == Account.MULTI_TOKEN_MODE) {
             revert AccountIsMultiToken(liquidatedAccountId);

--- a/core/src/storage/CollateralPool.sol
+++ b/core/src/storage/CollateralPool.sol
@@ -22,6 +22,8 @@ library CollateralPool {
     using SafeCastU256 for uint256;
     using SetUtil for SetUtil.AddressSet;
 
+    bytes32 private constant _COLLATERAL_POOL_ENABLED_FEATURE_FLAG = "collateralPoolEnabled";
+
     /**
      * @dev Thrown when a collateral pool cannot be found
      */
@@ -320,5 +322,9 @@ library CollateralPool {
         if (msg.sender != self.owner) {
             revert Unauthorized(msg.sender);
         }
+    }
+
+    function getEnabledFeatureFlagId(Data storage self) internal view returns(bytes32) {
+        return keccak256(abi.encode(_COLLATERAL_POOL_ENABLED_FEATURE_FLAG, self.id));
     }
 }


### PR DESCRIPTION
Feature that enables pausing and unpausing of collateral pools. It uses standard FeatureFlag support for access: 
- denyAll is true when the system is paused and allowAll is true when the system is active;
- deniers are equivalent to pausers (the actors that can switch denyAll to true);
- the only address that can un-pause (i.e. switch allowAll to true) is the owner;
- the allow list should be empty.