### PR TITLE
Update ExchangeStore.sol: Usage of 'immutable' for keccak variables

### DIFF
--- a/core/src/storage/ExchangeStore.sol
+++ b/core/src/storage/ExchangeStore.sol
@@ -15,7 +15,7 @@ pragma solidity >=0.8.19;
 // todo: lots of similarities with MarketStore, can we simplify?
 library ExchangeStore {
     // todo: replace xyz.voltz with reya.voltz (in all storage pointers)?
-    bytes32 private constant _SLOT_EXCHANGE_STORE = keccak256(abi.encode("xyz.voltz.ExchangeStore"));
+    bytes32 private immutable _SLOT_EXCHANGE_STORE = keccak256(abi.encode("xyz.voltz.ExchangeStore"));
 
     /**
      * @notice Emitted when the exchange store is created or updated


### PR DESCRIPTION
It's always advisable to use 'immutable' for keccak variables rather than 'constant'
Refer to this for a better explanation -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#change-constant-to-immutable-for-keccak-variables